### PR TITLE
Added to_i32 and to_u32 methods to f32x8 type

### DIFF
--- a/src/v256.rs
+++ b/src/v256.rs
@@ -329,6 +329,19 @@ impl i32x8 {
     }
 }
 
+impl f32x8 {
+    /// Convert each lane to a signed integer.
+    #[inline]
+    pub fn to_i32(self) -> i32x8 {
+        unsafe {simd_cast(self)}
+    }
+    /// Convert each lane to an unsigned integer.
+    #[inline]
+    pub fn to_u32(self) -> u32x8 {
+        unsafe {simd_cast(self)}
+    }
+}
+
 impl i16x16 {
     /// Convert each lane to an unsigned integer.
     #[inline]


### PR DESCRIPTION
The `f32x8` type doesn't provide a `to_i32` and `to_u32` methods which seems inconsistent since `f32x4` has them and so also `f64x2` and `f64x4` provide the 64bit version of those methods. So I assumed that this has just been overlooked and would like to add them with this pull request.

I haven't seen any tests for those types of conversion methods inside the crate. I therefore ran my tests by using `simd` from another crate. If you think that tests for those methods should be added than please let me know and I'll update this pull request.