### PR TITLE
Show all modules on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ description = """
 CPUs, as well as raw interfaces to platform-specific instructions.
 """
 
+[package.metadata.docs.rs]
+features = ["doc"]
+
 [dependencies]
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }


### PR DESCRIPTION
Add docs feature to docs.rs metadata, see https://github.com/onur/docs.rs/pull/73

Should fix #11