### PR TITLE
Make `any()` and `all()` on 128-bit ARMv7 NEON boolean vectors work

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,3 +226,573 @@ pub mod x86;
 pub mod arm;
 #[cfg(any(feature = "doc", target_arch = "aarch64"))]
 pub mod aarch64;
+
+#[cfg(test)]
+mod tests {
+
+    use super::u8x16;
+    use super::u16x8;
+    use super::u32x4;
+    use super::f32x4;
+
+    #[test]
+    fn test_u8x16_none_not_any() {
+        let x1 = u8x16::splat(1);
+        let x2 = u8x16::splat(2);
+        assert!(!(x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u8x16_none_not_all() {
+        let x1 = u8x16::splat(1);
+        let x2 = u8x16::splat(2);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u8x16_all_any() {
+        let x1 = u8x16::splat(1);
+        let x2 = u8x16::splat(1);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u8x16_all_all() {
+        let x1 = u8x16::splat(1);
+        let x2 = u8x16::splat(1);
+        assert!((x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u8x16_except_last_any() {
+        let x1 = u8x16::new(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1);
+        let x2 = u8x16::splat(2);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u8x16_except_last_not_all() {
+        let x1 = u8x16::new(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1);
+        let x2 = u8x16::splat(2);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u8x16_except_first_any() {
+        let x1 = u8x16::new(1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
+        let x2 = u8x16::splat(2);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u8x16_except_first_not_all() {
+        let x1 = u8x16::new(1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
+        let x2 = u8x16::splat(2);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u8x16_only_last_any() {
+        let x1 = u8x16::new(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1);
+        let x2 = u8x16::splat(1);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u8x16_only_last_not_all() {
+        let x1 = u8x16::new(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1);
+        let x2 = u8x16::splat(1);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u8x16_only_first_any() {
+        let x1 = u8x16::new(1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
+        let x2 = u8x16::splat(1);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u8x16_only_first_not_all() {
+        let x1 = u8x16::new(1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
+        let x2 = u8x16::splat(1);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u8x16_except_thirteenth_any() {
+        let x1 = u8x16::new(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2);
+        let x2 = u8x16::splat(2);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u8x16_except_thirteenth_not_all() {
+        let x1 = u8x16::new(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2);
+        let x2 = u8x16::splat(2);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u8x16_except_fifth_any() {
+        let x1 = u8x16::new(2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
+        let x2 = u8x16::splat(2);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u8x16_except_fifth_not_all() {
+        let x1 = u8x16::new(2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
+        let x2 = u8x16::splat(2);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u8x16_only_thirteenth_any() {
+        let x1 = u8x16::new(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2);
+        let x2 = u8x16::splat(1);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u8x16_only_thirteenth_not_all() {
+        let x1 = u8x16::new(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2);
+        let x2 = u8x16::splat(1);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u8x16_only_fifth_any() {
+        let x1 = u8x16::new(2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
+        let x2 = u8x16::splat(1);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u8x16_only_fifth_not_all() {
+        let x1 = u8x16::new(2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
+        let x2 = u8x16::splat(1);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u16x8_none_not_any() {
+        let x1 = u16x8::splat(1);
+        let x2 = u16x8::splat(2);
+        assert!(!(x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u16x8_none_not_all() {
+        let x1 = u16x8::splat(1);
+        let x2 = u16x8::splat(2);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u16x8_all_any() {
+        let x1 = u16x8::splat(1);
+        let x2 = u16x8::splat(1);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u16x8_all_all() {
+        let x1 = u16x8::splat(1);
+        let x2 = u16x8::splat(1);
+        assert!((x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u16x8_except_last_any() {
+        let x1 = u16x8::new(2, 2, 2, 2, 2, 2, 2, 1);
+        let x2 = u16x8::splat(2);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u16x8_except_last_not_all() {
+        let x1 = u16x8::new(2, 2, 2, 2, 2, 2, 2, 1);
+        let x2 = u16x8::splat(2);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u16x8_except_first_any() {
+        let x1 = u16x8::new(1, 2, 2, 2, 2, 2, 2, 2);
+        let x2 = u16x8::splat(2);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u16x8_except_first_not_all() {
+        let x1 = u16x8::new(1, 2, 2, 2, 2, 2, 2, 2);
+        let x2 = u16x8::splat(2);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u16x8_only_last_any() {
+        let x1 = u16x8::new(2, 2, 2, 2, 2, 2, 2, 1);
+        let x2 = u16x8::splat(1);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u16x8_only_last_not_all() {
+        let x1 = u16x8::new(2, 2, 2, 2, 2, 2, 2, 1);
+        let x2 = u16x8::splat(1);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u16x8_only_first_any() {
+        let x1 = u16x8::new(1, 2, 2, 2, 2, 2, 2, 2);
+        let x2 = u16x8::splat(1);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u16x8_only_first_not_all() {
+        let x1 = u16x8::new(1, 2, 2, 2, 2, 2, 2, 2);
+        let x2 = u16x8::splat(1);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u16x8_except_sixth_any() {
+        let x1 = u16x8::new(2, 2, 2, 2, 2, 1, 2, 2);
+        let x2 = u16x8::splat(2);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u16x8_except_sixth_not_all() {
+        let x1 = u16x8::new(2, 2, 2, 2, 2, 1, 2, 2);
+        let x2 = u16x8::splat(2);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u16x8_except_third_any() {
+        let x1 = u16x8::new(2, 2, 1, 2, 2, 2, 2, 2);
+        let x2 = u16x8::splat(2);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u16x8_except_third_not_all() {
+        let x1 = u16x8::new(2, 2, 1, 2, 2, 2, 2, 2);
+        let x2 = u16x8::splat(2);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u16x8_only_sixth_any() {
+        let x1 = u16x8::new(2, 2, 2, 2, 2, 1, 2, 2);
+        let x2 = u16x8::splat(1);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u16x8_only_sixth_not_all() {
+        let x1 = u16x8::new(2, 2, 2, 2, 2, 1, 2, 2);
+        let x2 = u16x8::splat(1);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u16x8_only_third_any() {
+        let x1 = u16x8::new(2, 2, 1, 2, 2, 2, 2, 2);
+        let x2 = u16x8::splat(1);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u16x8_only_third_not_all() {
+        let x1 = u16x8::new(2, 2, 1, 2, 2, 2, 2, 2);
+        let x2 = u16x8::splat(1);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u32x4_none_not_any() {
+        let x1 = u32x4::splat(1);
+        let x2 = u32x4::splat(2);
+        assert!(!(x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u32x4_none_not_all() {
+        let x1 = u32x4::splat(1);
+        let x2 = u32x4::splat(2);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u32x4_all_any() {
+        let x1 = u32x4::splat(1);
+        let x2 = u32x4::splat(1);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u32x4_all_all() {
+        let x1 = u32x4::splat(1);
+        let x2 = u32x4::splat(1);
+        assert!((x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u32x4_except_last_any() {
+        let x1 = u32x4::new(2, 2, 2, 1);
+        let x2 = u32x4::splat(2);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u32x4_except_last_not_all() {
+        let x1 = u32x4::new(2, 2, 2, 1);
+        let x2 = u32x4::splat(2);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u32x4_except_first_any() {
+        let x1 = u32x4::new(1, 2, 2, 2);
+        let x2 = u32x4::splat(2);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u32x4_except_first_not_all() {
+        let x1 = u32x4::new(1, 2, 2, 2);
+        let x2 = u32x4::splat(2);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u32x4_only_last_any() {
+        let x1 = u32x4::new(2, 2, 2, 1);
+        let x2 = u32x4::splat(1);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u32x4_only_last_not_all() {
+        let x1 = u32x4::new(2, 2, 2, 1);
+        let x2 = u32x4::splat(1);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u32x4_only_first_any() {
+        let x1 = u32x4::new(1, 2, 2, 2);
+        let x2 = u32x4::splat(1);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u32x4_only_first_not_all() {
+        let x1 = u32x4::new(1, 2, 2, 2);
+        let x2 = u32x4::splat(1);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u32x4_except_second_any() {
+        let x1 = u32x4::new(1, 2, 2, 2);
+        let x2 = u32x4::splat(2);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u32x4_except_second_not_all() {
+        let x1 = u32x4::new(1, 2, 2, 2);
+        let x2 = u32x4::splat(2);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u32x4_except_third_any() {
+        let x1 = u32x4::new(2, 2, 1, 2);
+        let x2 = u32x4::splat(2);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u32x4_except_third_not_all() {
+        let x1 = u32x4::new(2, 2, 1, 2);
+        let x2 = u32x4::splat(2);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u32x4_only_second_any() {
+        let x1 = u32x4::new(1, 2, 2, 2);
+        let x2 = u32x4::splat(1);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u32x4_only_second_not_all() {
+        let x1 = u32x4::new(1, 2, 2, 2);
+        let x2 = u32x4::splat(1);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_u32x4_only_third_any() {
+        let x1 = u32x4::new(2, 2, 1, 2);
+        let x2 = u32x4::splat(1);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_u32x4_only_third_not_all() {
+        let x1 = u32x4::new(2, 2, 1, 2);
+        let x2 = u32x4::splat(1);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_f32x4_none_not_any() {
+        let x1 = f32x4::splat(1.0);
+        let x2 = f32x4::splat(2.0);
+        assert!(!(x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_f32x4_none_not_all() {
+        let x1 = f32x4::splat(1.0);
+        let x2 = f32x4::splat(2.0);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_f32x4_all_any() {
+        let x1 = f32x4::splat(1.0);
+        let x2 = f32x4::splat(1.0);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_f32x4_all_all() {
+        let x1 = f32x4::splat(1.0);
+        let x2 = f32x4::splat(1.0);
+        assert!((x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_f32x4_except_last_any() {
+        let x1 = f32x4::new(2.0, 2.0, 2.0, 1.0);
+        let x2 = f32x4::splat(2.0);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_f32x4_except_last_not_all() {
+        let x1 = f32x4::new(2.0, 2.0, 2.0, 1.0);
+        let x2 = f32x4::splat(2.0);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_f32x4_except_first_any() {
+        let x1 = f32x4::new(1.0, 2.0, 2.0, 2.0);
+        let x2 = f32x4::splat(2.0);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_f32x4_except_first_not_all() {
+        let x1 = f32x4::new(1.0, 2.0, 2.0, 2.0);
+        let x2 = f32x4::splat(2.0);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_f32x4_only_last_any() {
+        let x1 = f32x4::new(2.0, 2.0, 2.0, 1.0);
+        let x2 = f32x4::splat(1.0);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_f32x4_only_last_not_all() {
+        let x1 = f32x4::new(2.0, 2.0, 2.0, 1.0);
+        let x2 = f32x4::splat(1.0);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_f32x4_only_first_any() {
+        let x1 = f32x4::new(1.0, 2.0, 2.0, 2.0);
+        let x2 = f32x4::splat(1.0);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_f32x4_only_first_not_all() {
+        let x1 = f32x4::new(1.0, 2.0, 2.0, 2.0);
+        let x2 = f32x4::splat(1.0);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_f32x4_except_second_any() {
+        let x1 = f32x4::new(1.0, 2.0, 2.0, 2.0);
+        let x2 = f32x4::splat(2.0);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_f32x4_except_second_not_all() {
+        let x1 = f32x4::new(1.0, 2.0, 2.0, 2.0);
+        let x2 = f32x4::splat(2.0);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_f32x4_except_third_any() {
+        let x1 = f32x4::new(2.0, 2.0, 1.0, 2.0);
+        let x2 = f32x4::splat(2.0);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_f32x4_except_third_not_all() {
+        let x1 = f32x4::new(2.0, 2.0, 1.0, 2.0);
+        let x2 = f32x4::splat(2.0);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_f32x4_only_second_any() {
+        let x1 = f32x4::new(1.0, 2.0, 2.0, 2.0);
+        let x2 = f32x4::splat(1.0);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_f32x4_only_second_not_all() {
+        let x1 = f32x4::new(1.0, 2.0, 2.0, 2.0);
+        let x2 = f32x4::splat(1.0);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+    #[test]
+    fn test_f32x4_only_third_any() {
+        let x1 = f32x4::new(2.0, 2.0, 1.0, 2.0);
+        let x2 = f32x4::splat(1.0);
+        assert!((x1.eq(x2)).any());
+    }
+
+    #[test]
+    fn test_f32x4_only_third_not_all() {
+        let x1 = f32x4::new(2.0, 2.0, 1.0, 2.0);
+        let x2 = f32x4::splat(1.0);
+        assert!(!(x1.eq(x2)).all());
+    }
+
+}


### PR DESCRIPTION
Use shuffles instead of transmutes for accessing aliased half-registers. Implement the `Simd` trait for more types in order to satisfy the trait bounds of the shuffle intrinsic declarations. Bitcast to `u32x2` before extracting data to an ALU register. In the `all()` case, compare with `0xFFFFFFFF` instead of zero.

Closes #12.

`cargo test` is broken in upstream, but I have verified that the tests pass on armv7+neon when pasted into a separate crate.

I have checked that

```rust
#[inline(never)]
pub extern "C" fn any(a: u8x16, b: u8x16) -> bool {
    (a.eq(b)).any()
}
```

compiles to

```asm
_ZN9check_asm3any17he77c27841e1c1337E:
	.fnstart
	vceq.i8	q0, q0, q1
	vpmax.u8	d0, d0, d1
	vpmax.u8	d0, d0, d0
	vmov.32	r0, d0[0]
	cmp	r0, #0
	movwne	r0, #1
	bx	lr
.Lfunc_end0:
	.size	_ZN9check_asm3any17he77c27841e1c1337E, .Lfunc_end0-_ZN9check_asm3any17he77c27841e1c1337E
	.fnend
```

Filling out the rest of the implementation for the 64-bit NEON SIMD types is left as an exercise to the first person who needs a more complete implementation.

r? @BurntSushi 